### PR TITLE
Add Dokkan Sensha Deluxe car washing mini-game

### DIFF
--- a/dokkan_sensya_deluxe/index.html
+++ b/dokkan_sensya_deluxe/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ドッカン洗車デラックス</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <header class="hud">
+        <div class="hud__item">
+          <span class="hud__label">スコア</span>
+          <span id="score" class="hud__value">0</span>
+        </div>
+        <div class="hud__item hud__meter">
+          <span class="hud__label">タイム</span>
+          <div class="meter">
+            <span id="time-fill" class="meter__fill"></span>
+          </div>
+        </div>
+        <div class="hud__item hud__meter">
+          <span class="hud__label">ドッカンゲージ</span>
+          <div class="meter meter--dokkan">
+            <span id="dokkan-fill" class="meter__fill"></span>
+          </div>
+        </div>
+        <div class="hud__item">
+          <span class="hud__label">連続洗浄</span>
+          <span id="combo" class="hud__value">0</span>
+        </div>
+      </header>
+
+      <section class="stage">
+        <canvas id="game" width="960" height="540" aria-label="ドッカン洗車デラックスのプレイフィールド"></canvas>
+        <div id="overlay" class="overlay">
+          <div class="overlay__panel" id="title-panel">
+            <h1>ドッカン洗車デラックス</h1>
+            <p>
+              強力洗浄スプラッシュで汚れを吹き飛ばせ！<br />
+              マウスまたはタッチで水を噴射、ブラシ洗浄でコンボを繋げて
+              ドッカンモードを発動しよう。
+            </p>
+            <button id="start-button" type="button" class="btn">スタート！</button>
+          </div>
+          <div class="overlay__panel" id="result-panel" hidden>
+            <h2 id="result-title">クリア！</h2>
+            <p id="result-message"></p>
+            <button id="retry-button" type="button" class="btn">もう一度</button>
+          </div>
+        </div>
+      </section>
+
+      <footer class="help">
+        <p>
+          <strong>操作:</strong> マウスまたは指でドラッグして噴射。<br />
+          長押しで水圧アップ。素早く汚れを落とすとコンボが続き、ゲージがMAXになると
+          <span class="highlight">ドッカンモード</span>が発動！
+        </p>
+      </footer>
+    </main>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/dokkan_sensya_deluxe/script.js
+++ b/dokkan_sensya_deluxe/script.js
@@ -1,0 +1,475 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const overlay = document.getElementById('overlay');
+const titlePanel = document.getElementById('title-panel');
+const resultPanel = document.getElementById('result-panel');
+const resultTitle = document.getElementById('result-title');
+const resultMessage = document.getElementById('result-message');
+const startButton = document.getElementById('start-button');
+const retryButton = document.getElementById('retry-button');
+const scoreEl = document.getElementById('score');
+const comboEl = document.getElementById('combo');
+const timeFill = document.getElementById('time-fill');
+const dokkanFill = document.getElementById('dokkan-fill');
+
+const config = {
+  baseTime: 70,
+  extraTimePerCombo: 0.15,
+  dirtCount: 120,
+  dirtRadius: [16, 48],
+  sprayRadius: [38, 64],
+  sprayStrength: 0.8,
+  dokkanChargePerClean: 0.016,
+  dokkanDuration: 5.5,
+  dokkanBonus: 1.8,
+};
+
+const state = {
+  phase: 'title',
+  score: 0,
+  combo: 0,
+  bestCombo: 0,
+  timeLeft: config.baseTime,
+  lastCleanTime: 0,
+  dokkanGauge: 0,
+  dokkanTime: 0,
+  dirtSpots: [],
+  foam: [],
+  waterRipples: [],
+  pointer: { active: false, x: 0, y: 0, radius: 48, intensity: 0 },
+  viewWidth: canvas.width,
+  viewHeight: canvas.height,
+  dpr: window.devicePixelRatio || 1,
+};
+
+let lastTimestamp = performance.now();
+
+function resizeCanvas() {
+  const dpr = window.devicePixelRatio || 1;
+  const rectWidth = Math.min(window.innerWidth * 0.96, 980);
+  const rectHeight = Math.min(window.innerHeight * 0.58, 560);
+
+  canvas.width = rectWidth * dpr;
+  canvas.height = rectHeight * dpr;
+  canvas.style.width = `${rectWidth}px`;
+  canvas.style.height = `${rectHeight}px`;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  state.viewWidth = rectWidth;
+  state.viewHeight = rectHeight;
+  state.dpr = dpr;
+}
+
+resizeCanvas();
+window.addEventListener('resize', resizeCanvas);
+
+function randomBetween([min, max]) {
+  return Math.random() * (max - min) + min;
+}
+
+function easeOutCubic(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function resetGame() {
+  state.phase = 'playing';
+  state.score = 0;
+  state.combo = 0;
+  state.bestCombo = 0;
+  state.timeLeft = config.baseTime;
+  state.lastCleanTime = 0;
+  state.dokkanGauge = 0;
+  state.dokkanTime = 0;
+  state.dirtSpots = generateDirt();
+  state.foam = [];
+  state.waterRipples = [];
+  state.pointer.active = false;
+  state.pointer.intensity = 0;
+}
+
+function generateDirt() {
+  const { viewWidth: width, viewHeight: height } = state;
+  const carBounds = {
+    x: width * 0.12,
+    y: height * 0.32,
+    width: width * 0.76,
+    height: height * 0.42,
+  };
+
+  const spots = [];
+  for (let i = 0; i < config.dirtCount; i += 1) {
+    const radius = randomBetween(config.dirtRadius);
+    const x = carBounds.x + Math.random() * carBounds.width;
+    const y = carBounds.y + (Math.random() ** 0.6) * carBounds.height;
+    const strength = 0.6 + Math.random() * 0.8;
+    spots.push({ x, y, radius, strength, remaining: strength });
+  }
+  return spots;
+}
+
+function setOverlay(visible, panel) {
+  if (visible) {
+    overlay.classList.remove('hidden');
+    titlePanel.hidden = panel !== 'title';
+    resultPanel.hidden = panel !== 'result';
+  } else {
+    overlay.classList.add('hidden');
+  }
+}
+
+startButton.addEventListener('click', () => {
+  resetGame();
+  setOverlay(false);
+});
+
+retryButton.addEventListener('click', () => {
+  resetGame();
+  setOverlay(false);
+});
+
+canvas.addEventListener('pointerdown', (event) => {
+  if (state.phase !== 'playing') return;
+  canvas.setPointerCapture(event.pointerId);
+  updatePointer(event);
+  state.pointer.active = true;
+});
+
+canvas.addEventListener('pointerup', (event) => {
+  if (state.phase !== 'playing') return;
+  canvas.releasePointerCapture(event.pointerId);
+  state.pointer.active = false;
+  state.pointer.intensity = 0;
+});
+
+canvas.addEventListener('pointerleave', () => {
+  state.pointer.active = false;
+  state.pointer.intensity = 0;
+});
+
+canvas.addEventListener('pointermove', (event) => {
+  if (state.phase !== 'playing') return;
+  updatePointer(event);
+});
+
+function updatePointer(event) {
+  const rect = canvas.getBoundingClientRect();
+  state.pointer.x = event.clientX - rect.left;
+  state.pointer.y = event.clientY - rect.top;
+  state.pointer.radius = randomBetween(config.sprayRadius);
+  if (state.pointer.active) {
+    state.pointer.intensity = Math.min(1, state.pointer.intensity + 0.08);
+  }
+}
+
+function update(dt) {
+  if (state.phase !== 'playing') return;
+
+  state.timeLeft = Math.max(0, state.timeLeft - dt);
+  if (state.timeLeft === 0 || state.dirtSpots.length === 0) {
+    endGame();
+    return;
+  }
+
+  if (state.dokkanTime > 0) {
+    state.dokkanTime = Math.max(0, state.dokkanTime - dt);
+  }
+
+  if (state.pointer.active) {
+    sprayWater(dt);
+  } else {
+    state.pointer.intensity = Math.max(0, state.pointer.intensity - dt * 2);
+  }
+
+  updateFoam(dt);
+  updateRipples(dt);
+}
+
+function sprayWater(dt) {
+  const { x, y, radius, intensity } = state.pointer;
+  const brushRadius = radius * (0.7 + intensity * 0.6);
+  const brushStrength = config.sprayStrength * (1 + intensity) * (state.dokkanTime > 0 ? config.dokkanBonus : 1);
+
+  let cleanedSomething = false;
+  for (let i = state.dirtSpots.length - 1; i >= 0; i -= 1) {
+    const spot = state.dirtSpots[i];
+    const dx = spot.x - x;
+    const dy = spot.y - y;
+    const dist = Math.hypot(dx, dy);
+    const influence = brushRadius + spot.radius * 0.6;
+    if (dist < influence) {
+      const falloff = 1 - dist / influence;
+      const scrub = brushStrength * (0.45 + falloff * 0.8) * dt;
+      spot.remaining = Math.max(0, spot.remaining - scrub);
+      if (spot.remaining === 0) {
+        state.dirtSpots.splice(i, 1);
+        state.score += Math.round(80 + Math.random() * 40 + state.combo * 4);
+        cleanedSomething = true;
+        state.dokkanGauge = Math.min(1, state.dokkanGauge + config.dokkanChargePerClean);
+        if (state.dokkanGauge === 1 && state.dokkanTime === 0) {
+          state.dokkanTime = config.dokkanDuration;
+          state.dokkanGauge = 0;
+          addRipple(x, y, true);
+        }
+      } else {
+        cleanedSomething = true;
+      }
+      addFoam(x + dx * 0.2, y + dy * 0.2, Math.max(spot.radius * 0.2, 12));
+    }
+  }
+
+  if (cleanedSomething) {
+    const now = performance.now();
+    if (now - state.lastCleanTime < 1200) {
+      state.combo += 1;
+      state.bestCombo = Math.max(state.bestCombo, state.combo);
+      state.timeLeft = Math.min(config.baseTime, state.timeLeft + config.extraTimePerCombo);
+    } else {
+      state.combo = 1;
+    }
+    state.lastCleanTime = now;
+    addRipple(x, y, state.dokkanTime > 0);
+  } else if (performance.now() - state.lastCleanTime > 1600) {
+    state.combo = 0;
+  }
+}
+
+function endGame() {
+  state.phase = 'result';
+  resultTitle.textContent = state.dirtSpots.length === 0 ? 'ピカピカ！' : '時間切れ';
+  const cleaned = config.dirtCount - state.dirtSpots.length;
+  const percentage = Math.round((cleaned / config.dirtCount) * 100);
+  resultMessage.textContent = `洗浄率 ${percentage}% / ベスト連続 ${state.bestCombo} コンボ / スコア ${state.score.toLocaleString('ja-JP')}`;
+  setOverlay(true, 'result');
+}
+
+function updateFoam(dt) {
+  for (let i = state.foam.length - 1; i >= 0; i -= 1) {
+    const bubble = state.foam[i];
+    bubble.life -= dt;
+    bubble.y -= dt * 18;
+    bubble.radius += dt * 6;
+    if (bubble.life <= 0) {
+      state.foam.splice(i, 1);
+    }
+  }
+}
+
+function addFoam(x, y, radius) {
+  for (let i = 0; i < 3; i += 1) {
+    state.foam.push({
+      x: x + (Math.random() - 0.5) * radius * 1.4,
+      y: y + (Math.random() - 0.5) * radius * 0.6,
+      radius: radius * (0.6 + Math.random() * 0.5),
+      life: 0.6 + Math.random() * 0.4,
+    });
+  }
+}
+
+function addRipple(x, y, dokkan) {
+  state.waterRipples.push({
+    x,
+    y,
+    radius: 10,
+    life: dokkan ? 0.5 : 0.35,
+    age: 0,
+    dokkan,
+  });
+}
+
+function updateRipples(dt) {
+  for (let i = state.waterRipples.length - 1; i >= 0; i -= 1) {
+    const ripple = state.waterRipples[i];
+    ripple.age += dt;
+    ripple.radius += dt * (ripple.dokkan ? 360 : 220);
+    if (ripple.age > ripple.life) {
+      state.waterRipples.splice(i, 1);
+    }
+  }
+}
+
+function drawBackground() {
+  const { viewWidth: width, viewHeight: height } = state;
+
+  const gradient = ctx.createLinearGradient(0, 0, width * 0.3, height);
+  gradient.addColorStop(0, '#0b1b2f');
+  gradient.addColorStop(1, '#02060a');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = 'rgba(10, 20, 34, 0.9)';
+  ctx.fillRect(width * 0.05, height * 0.65, width * 0.9, height * 0.12);
+
+  ctx.fillStyle = 'rgba(21, 43, 70, 0.7)';
+  ctx.fillRect(width * 0.05, height * 0.77, width * 0.9, height * 0.05);
+}
+
+function drawCar() {
+  const { viewWidth: width, viewHeight: height } = state;
+  const centerY = height * 0.6;
+  const carWidth = width * 0.72;
+  const carHeight = height * 0.34;
+  const startX = (width - carWidth) / 2;
+
+  ctx.save();
+  ctx.translate(startX, centerY - carHeight * 0.75);
+
+  const carBodyGradient = ctx.createLinearGradient(0, 0, 0, carHeight);
+  carBodyGradient.addColorStop(0, '#2e8fff');
+  carBodyGradient.addColorStop(0.6, '#0b3c7a');
+  carBodyGradient.addColorStop(1, '#071c3a');
+
+  ctx.fillStyle = carBodyGradient;
+  ctx.beginPath();
+  ctx.moveTo(carWidth * 0.05, carHeight * 0.75);
+  ctx.quadraticCurveTo(carWidth * 0.12, carHeight * 0.2, carWidth * 0.36, carHeight * 0.12);
+  ctx.quadraticCurveTo(carWidth * 0.48, carHeight * 0.04, carWidth * 0.64, carHeight * 0.12);
+  ctx.quadraticCurveTo(carWidth * 0.88, carHeight * 0.2, carWidth * 0.95, carHeight * 0.72);
+  ctx.lineTo(carWidth * 0.95, carHeight * 0.9);
+  ctx.quadraticCurveTo(carWidth * 0.8, carHeight * 1.05, carWidth * 0.7, carHeight * 1.05);
+  ctx.lineTo(carWidth * 0.28, carHeight * 1.05);
+  ctx.quadraticCurveTo(carWidth * 0.16, carHeight * 1.05, carWidth * 0.05, carHeight * 0.9);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.12)';
+  ctx.beginPath();
+  ctx.moveTo(carWidth * 0.2, carHeight * 0.3);
+  ctx.quadraticCurveTo(carWidth * 0.36, carHeight * 0.12, carWidth * 0.52, carHeight * 0.28);
+  ctx.lineTo(carWidth * 0.72, carHeight * 0.36);
+  ctx.quadraticCurveTo(carWidth * 0.52, carHeight * 0.52, carWidth * 0.24, carHeight * 0.52);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = '#111a28';
+  ctx.beginPath();
+  ctx.arc(carWidth * 0.25, carHeight * 1.02, carHeight * 0.25, 0, Math.PI * 2);
+  ctx.arc(carWidth * 0.75, carHeight * 1.02, carHeight * 0.25, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#d9e6ef';
+  ctx.beginPath();
+  ctx.arc(carWidth * 0.25, carHeight * 1.02, carHeight * 0.15, 0, Math.PI * 2);
+  ctx.arc(carWidth * 0.75, carHeight * 1.02, carHeight * 0.15, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+  ctx.fillRect(carWidth * 0.64, carHeight * 0.7, carWidth * 0.18, carHeight * 0.18);
+
+  ctx.restore();
+}
+
+function drawDirt() {
+  ctx.save();
+  ctx.globalCompositeOperation = 'multiply';
+  for (const spot of state.dirtSpots) {
+    const alpha = easeOutCubic(spot.remaining / spot.strength);
+    const grad = ctx.createRadialGradient(spot.x, spot.y, spot.radius * 0.1, spot.x, spot.y, spot.radius);
+    grad.addColorStop(0, `rgba(92, 62, 32, ${0.75 * alpha})`);
+    grad.addColorStop(1, `rgba(32, 20, 12, ${0.05 * alpha})`);
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(spot.x, spot.y, spot.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawFoam() {
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  for (const bubble of state.foam) {
+    const alpha = bubble.life / 1.1;
+    const gradient = ctx.createRadialGradient(
+      bubble.x,
+      bubble.y,
+      bubble.radius * 0.1,
+      bubble.x,
+      bubble.y,
+      bubble.radius
+    );
+    gradient.addColorStop(0, `rgba(255, 255, 255, ${0.9 * alpha})`);
+    gradient.addColorStop(1, `rgba(230, 248, 255, 0)`);
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(bubble.x, bubble.y, bubble.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawRipples() {
+  ctx.save();
+  ctx.lineWidth = 3;
+  for (const ripple of state.waterRipples) {
+    const lifeRatio = 1 - ripple.age / ripple.life;
+    ctx.strokeStyle = ripple.dokkan
+      ? `rgba(255, 186, 85, ${lifeRatio * 0.65})`
+      : `rgba(130, 210, 255, ${lifeRatio * 0.6})`;
+    ctx.beginPath();
+    ctx.arc(ripple.x, ripple.y, ripple.radius, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawPointer() {
+  if (!state.pointer.active) return;
+  ctx.save();
+  const { x, y, radius, intensity } = state.pointer;
+  const gradient = ctx.createRadialGradient(x, y, 0, x, y, radius * 0.8);
+  gradient.addColorStop(0, `rgba(120, 200, 255, ${0.2 + intensity * 0.4})`);
+  gradient.addColorStop(1, 'rgba(120, 200, 255, 0)');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 0.8, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawDokkanAura() {
+  if (state.dokkanTime <= 0) return;
+  const { viewWidth: width, viewHeight: height } = state;
+  const intensity = easeOutCubic(state.dokkanTime / config.dokkanDuration);
+  const gradient = ctx.createRadialGradient(
+    width / 2,
+    height * 0.55,
+    width * 0.1,
+    width / 2,
+    height * 0.55,
+    width * 0.6
+  );
+  gradient.addColorStop(0, `rgba(255, 196, 120, ${0.25 * intensity})`);
+  gradient.addColorStop(1, 'rgba(255, 130, 40, 0)');
+  ctx.save();
+  ctx.globalCompositeOperation = 'screen';
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+}
+
+function render() {
+  drawBackground();
+  drawDokkanAura();
+  drawCar();
+  drawDirt();
+  drawFoam();
+  drawRipples();
+  drawPointer();
+
+  scoreEl.textContent = state.score.toLocaleString('ja-JP');
+  comboEl.textContent = state.combo;
+  timeFill.style.transform = `scaleX(${state.timeLeft / config.baseTime})`;
+  dokkanFill.style.transform = `scaleX(${state.dokkanTime > 0 ? 1 : state.dokkanGauge})`;
+}
+
+function loop(timestamp) {
+  const dt = Math.min((timestamp - lastTimestamp) / 1000, 0.05);
+  lastTimestamp = timestamp;
+
+  update(dt);
+  render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);
+
+setOverlay(true, 'title');

--- a/dokkan_sensya_deluxe/style.css
+++ b/dokkan_sensya_deluxe/style.css
@@ -1,0 +1,183 @@
+:root {
+  color-scheme: dark light;
+  font-family: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', sans-serif;
+  --bg: radial-gradient(circle at top, #0f1c2c 0%, #05070c 70%);
+  --card: rgba(13, 26, 43, 0.85);
+  --accent: #2ec4ff;
+  --accent-strong: #81f5ff;
+  --dokkan: #ffb347;
+  --text-light: #f2f8ff;
+  --text-dim: #88a0c2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  color: var(--text-light);
+}
+
+.layout {
+  width: min(1100px, 100vw);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1.5rem;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  background: var(--card);
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(12px);
+}
+
+.hud__label {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.hud__value {
+  font-size: clamp(1.6rem, 2.5vw, 2.4rem);
+  font-weight: 700;
+}
+
+.hud__meter {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.meter {
+  position: relative;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.meter--dokkan {
+  height: 18px;
+}
+
+.meter__fill {
+  position: absolute;
+  inset: 0;
+  width: 50%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-strong) 100%);
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 0.2s ease-out;
+}
+
+.meter--dokkan .meter__fill {
+  background: linear-gradient(90deg, #ff5f6d 0%, var(--dokkan) 100%);
+}
+
+.stage {
+  position: relative;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: rgba(9, 17, 28, 0.65);
+  box-shadow: 0 2rem 4rem rgba(0, 0, 0, 0.45);
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(5, 11, 18, 0.72);
+  color: var(--text-light);
+}
+
+.overlay.hidden {
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.overlay__panel {
+  max-width: min(520px, 90%);
+  text-align: center;
+  background: rgba(14, 29, 48, 0.85);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border-radius: 1.25rem;
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.5);
+}
+
+.overlay__panel h1,
+.overlay__panel h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.overlay__panel p {
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.btn {
+  appearance: none;
+  border: none;
+  padding: 0.8rem 2.5rem;
+  border-radius: 999px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0a1827;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 1rem 2rem rgba(46, 196, 255, 0.3);
+}
+
+.help {
+  background: rgba(11, 22, 38, 0.75);
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-dim);
+  line-height: 1.7;
+}
+
+.highlight {
+  color: var(--accent-strong);
+}
+
+@media (max-width: 720px) {
+  .hud {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .overlay {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new Dokkan Sensha Deluxe single-page web experience with HUD, stage, and overlay screens
- implement canvas-based car washing gameplay with combos, dokkan mode boosts, foam particles, and ripple effects
- style the layout with neon glassmorphism, responsive meters, and instructional footer

## Testing
- not run (static web content)


------
https://chatgpt.com/codex/tasks/task_b_68e604580334832da03940f13785cdf8